### PR TITLE
added sleep to account for prompt change display issue

### DIFF
--- a/msf_prompt/msf_prompt_styles.py
+++ b/msf_prompt/msf_prompt_styles.py
@@ -34,7 +34,7 @@ def get_formatted_prompt(raw_text):
         msf = re.findall("msf[0-9]?", raw_text)[0]
     except:
         # probably in an interactive shell
-        return [('', raw_text)]
+        return [("", raw_text)]
     try:
         premodule = re.findall("( [\w]+)\(", raw_text)[0]
     except:


### PR DESCRIPTION
This isn't very elegant at all, but it seems to get the job done.  I was hoping to be able to call the console.is_busy method, but there seems to be a race condition where that frees up, results haven't printed to the screen yet, and then the next prompt prints anyway